### PR TITLE
Order 및 OrderDetail에 대한 DTO, Entity 구현

### DIFF
--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
@@ -17,5 +17,5 @@ struct FSOrder: Decodable {
 
 struct FSOrderDetail: Decodable {
     let menuItemID: FSString
-    let amount: FSInteger
+    let quantity: FSInteger
 }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct FSOrders: Decodable {
+    let documents: [FSOrderDocument]
+}
+
+struct FSOrderDocument: Decodable {
+    let name: String
+    let fields: FSOrder
+}
+
+struct FSOrder: Decodable {
+    let id: FSString
+    let paymentDate: FSString
+    let orderDetails: FSArray<FSMap<FSFields<FSOrderDetail>>>
+}
+
+struct FSOrderDetail: Decodable {
+    let menuItemID: FSString
+    let amount: FSInteger
+}

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSTypes.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSTypes.swift
@@ -7,3 +7,19 @@ struct FSString: Decodable {
 struct FSInteger: Decodable {
     let integerValue: String
 }
+
+struct FSArray<T: Decodable>: Decodable {
+    let arrayValue: FSArrayValue<T>
+}
+
+struct FSArrayValue<T: Decodable>: Decodable {
+    let values: Array<T>
+}
+
+struct FSMap<T: Decodable>: Decodable {
+    let mapValue: T
+}
+
+struct FSFields<T: Decodable>: Decodable {
+    let fields: T
+}

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
@@ -41,4 +41,21 @@ final class FirestoreService {
             return nil
         }
     }
+
+    func fetchOrders() async -> FSOrders? {
+        let urlString = "\(baseURL)/orders"
+        guard let url = URL(string: urlString) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let result = try JSONDecoder().decode(FSOrders.self, from: data)
+            return result
+        } catch {
+            print("Firestore Error: \(error)")
+            return nil
+        }
+    }
 }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Domain/Entity/Order.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Domain/Entity/Order.swift
@@ -17,11 +17,11 @@ typealias Orders = [Order]
 
 struct OrderDetail {
     let menuItemID: String
-    let amount: Int
+    let quantity: Int
 
     init(from dto: FSOrderDetail) {
         self.menuItemID = dto.menuItemID.stringValue
-        self.amount = Int(dto.amount.integerValue) ?? 0
+        self.quantity = Int(dto.quantity.integerValue) ?? 0
     }
 }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Domain/Entity/Order.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Domain/Entity/Order.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct Order {
+    let id: String
+    let paymentDate: Date
+    let orderDetails: OrderDetails
+
+    init(from dto: FSOrder) {
+        self.id = dto.id.stringValue
+        self.paymentDate = Date(from: dto.paymentDate.stringValue) ?? Date(timeIntervalSince1970: 0)
+        self.orderDetails = dto.orderDetails.arrayValue.values
+            .map { OrderDetail(from: $0.mapValue.fields) }
+    }
+}
+
+typealias Orders = [Order]
+
+struct OrderDetail {
+    let menuItemID: String
+    let amount: Int
+
+    init(from dto: FSOrderDetail) {
+        self.menuItemID = dto.menuItemID.stringValue
+        self.amount = Int(dto.amount.integerValue) ?? 0
+    }
+}
+
+typealias OrderDetails = [OrderDetail]

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Utility/Date+Extensions.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Utility/Date+Extensions.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension Date {
+    init?(from isoString: String) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime] // "2025-04-08T22:54:31+09:00"
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+        guard let date = formatter.date(from: isoString) else { return nil }
+        self = date
+    }
+
+    var isoString: String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime] // "2025-04-08T22:54:31+09:00"
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+        return formatter.string(from: self)
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
close #25 

## 📌 PR 요약
Order 및 OrderDetail에 대한 DTO, Entity 구현

## 🔖 작업 내용
- [x] Order, OrderDetail DTO 정의(FSOrder, FSOrderDetail)
- [x] Order, OrderDetail Entity 정의
- [x] Firestore의 fetchOrders 구현
- [x] DTO 매핑을 위한 Date Extensions 구현

## 🎆 스크린샷
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/cc385351-96e0-4a64-9db1-d462dafa7c1d" />


## 💡 추가 참고 사항
아래 JSON 형태의 데이터를 파싱하기 위해 어쩔 수 없이 복잡한 구조로 구성했습니다.
<img width="494" alt="image" src="https://github.com/user-attachments/assets/3de3e9cf-c6dc-4ffb-995a-597bd4cf59c6" />

