### PR TITLE
Firestore 에러 처리 구현

### DIFF
--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FSError.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FSError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum FSError: Error {
+    case invalidURL
+    case httpError(statusCode: Int)
+    case noData
+    case decodingFailed(message: String)
+    case unknownError(message: String)
+}

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+fileprivate enum FSPath: String {
+    case categories
+    case menuItems
+    case orders
+}
+
 final class FirestoreService {
     private let projectID = "naeilburgercamp"
     private let databaseID = "(default)"
@@ -8,54 +14,49 @@ final class FirestoreService {
         "https://firestore.googleapis.com/v1/projects/\(projectID)/databases/\(databaseID)/documents"
     }
 
-    func fetchCategories() async -> FSCategories? {
-        let urlString = "\(baseURL)/categories"
-        guard let url = URL(string: urlString) else { return nil }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-
-        do {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            let result = try JSONDecoder().decode(FSCategories.self, from: data)
-            return result
-        } catch {
-            print("Firestore Error: \(error)")
-            return nil
-        }
+    func fetchCategories() async -> Result<FSCategories, FSError> {
+        await fetch(from: .categories, as: FSCategories.self)
     }
 
-    func fetchMenuItems() async -> FSMenuItems? {
-        let urlString = "\(baseURL)/menuItems"
-        guard let url = URL(string: urlString) else { return nil }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-
-        do {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            let result = try JSONDecoder().decode(FSMenuItems.self, from: data)
-            return result
-        } catch {
-            print("Firestore Error: \(error)")
-            return nil
-        }
+    func fetchMenuItems() async -> Result<FSMenuItems, FSError> {
+        await fetch(from: .menuItems, as: FSMenuItems.self)
     }
 
-    func fetchOrders() async -> FSOrders? {
-        let urlString = "\(baseURL)/orders"
-        guard let url = URL(string: urlString) else { return nil }
+    func fetchOrders() async -> Result<FSOrders, FSError> {
+        await fetch(from: .orders, as: FSOrders.self)
+    }
+}
+
+private extension FirestoreService {
+    func fetch<T: Decodable>(from path: FSPath, as type: T.Type) async -> Result<T, FSError> {
+        let urlString = "\(baseURL)/\(path)"
+        guard let url = URL(string: urlString) else {
+            return .failure(.invalidURL)
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
 
         do {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            let result = try JSONDecoder().decode(FSOrders.self, from: data)
-            return result
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200...299).contains(httpResponse.statusCode) {
+                return .failure(.httpError(statusCode: httpResponse.statusCode))
+            }
+
+            guard !data.isEmpty else {
+                return .failure(.noData)
+            }
+
+            do {
+                let result = try JSONDecoder().decode(T.self, from: data)
+                return .success(result)
+            } catch {
+                return .failure(.decodingFailed(message: error.localizedDescription))
+            }
         } catch {
-            print("Firestore Error: \(error)")
-            return nil
+            return .failure(.unknownError(message: error.localizedDescription))
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
close #12 

## 📌 PR 요약
Firestore에 대한 에러 처리 구현입니다.

## 🔖 작업 내용
- [x] FSError 정의
- [x] FirestoreService 에러 처리(Result 타입으로 반환)
- [x] fetch 중복 로직 제거하여 간소화
