### PR TITLE
FirestoreService.createOrder(_:) 구현

### DIFF
--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSCategory.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSCategory.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-struct FSCategories: Decodable {
+struct FSCategories: Codable {
     let documents: [FSCategoryDocument]
 }
 
-struct FSCategoryDocument: Decodable {
+struct FSCategoryDocument: Codable {
     let name: String
     let fields: FSCategory
 }
 
-struct FSCategory: Decodable {
+struct FSCategory: Codable {
     let id: FSString
     let title: FSString
     let sortOrder: FSInteger

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSMenuItem.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSMenuItem.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-struct FSMenuItems: Decodable {
+struct FSMenuItems: Codable {
     let documents: [FSMenuItemDocument]
 }
 
-struct FSMenuItemDocument: Decodable {
+struct FSMenuItemDocument: Codable {
     let name: String
     let fields: FSMenuItem
 }
 
-struct FSMenuItem: Decodable {
+struct FSMenuItem: Codable {
     let id: FSString
     let categoryID: FSString
     let title: FSString

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
@@ -9,6 +9,10 @@ struct FSOrderDocument: Codable {
     let fields: FSOrder
 }
 
+struct FSOrderDocumentForCreation: Codable {
+    let fields: FSOrder
+}
+
 struct FSOrder: Codable {
     let id: FSString
     let paymentDate: FSString

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
@@ -11,15 +11,37 @@ struct FSOrderDocument: Codable {
 
 struct FSOrderDocumentForCreation: Codable {
     let fields: FSOrder
+
+    init(from fsOrder: FSOrder) {
+        self.fields = fsOrder
+    }
 }
 
 struct FSOrder: Codable {
     let id: FSString
     let paymentDate: FSString
     let orderDetails: FSArray<FSMap<FSFields<FSOrderDetail>>>
+
+    init(from entity: Order) {
+        self.id = FSString(stringValue: entity.id)
+        self.paymentDate = FSString(stringValue: entity.paymentDate.isoString)
+        self.orderDetails = FSArray(
+            arrayValue: FSArrayValue(
+                values: entity.orderDetails
+                    .map {
+                        FSMap(mapValue: FSFields(fields: FSOrderDetail(from: $0)))
+                    }
+            )
+        )
+    }
 }
 
 struct FSOrderDetail: Codable {
     let menuItemID: FSString
     let quantity: FSInteger
+
+    init(from entity: OrderDetail) {
+        self.menuItemID = FSString(stringValue: entity.menuItemID)
+        self.quantity = FSInteger(integerValue: "\(entity.quantity)")
+    }
 }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSOrder.swift
@@ -1,21 +1,21 @@
 import Foundation
 
-struct FSOrders: Decodable {
+struct FSOrders: Codable {
     let documents: [FSOrderDocument]
 }
 
-struct FSOrderDocument: Decodable {
+struct FSOrderDocument: Codable {
     let name: String
     let fields: FSOrder
 }
 
-struct FSOrder: Decodable {
+struct FSOrder: Codable {
     let id: FSString
     let paymentDate: FSString
     let orderDetails: FSArray<FSMap<FSFields<FSOrderDetail>>>
 }
 
-struct FSOrderDetail: Decodable {
+struct FSOrderDetail: Codable {
     let menuItemID: FSString
     let quantity: FSInteger
 }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSTypes.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/DTO/FSTypes.swift
@@ -1,25 +1,25 @@
 import Foundation
 
-struct FSString: Decodable {
+struct FSString: Codable {
     let stringValue: String
 }
 
-struct FSInteger: Decodable {
+struct FSInteger: Codable {
     let integerValue: String
 }
 
-struct FSArray<T: Decodable>: Decodable {
+struct FSArray<T: Codable>: Codable {
     let arrayValue: FSArrayValue<T>
 }
 
-struct FSArrayValue<T: Decodable>: Decodable {
+struct FSArrayValue<T: Codable>: Codable {
     let values: Array<T>
 }
 
-struct FSMap<T: Decodable>: Decodable {
+struct FSMap<T: Codable>: Codable {
     let mapValue: T
 }
 
-struct FSFields<T: Decodable>: Decodable {
+struct FSFields<T: Codable>: Codable {
     let fields: T
 }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FSError.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FSError.swift
@@ -4,6 +4,7 @@ enum FSError: LocalizedError {
     case invalidURL(urlString: String)
     case httpError(statusCode: Int)
     case noData
+    case encodingFailed(message: String)
     case decodingFailed(message: String)
     case unknownError(message: String)
 
@@ -15,6 +16,8 @@ enum FSError: LocalizedError {
             return "HTTPError: \(statusCode)"
         case .noData:
             return "NoData"
+        case .encodingFailed(let message):
+            return "EncodingFailed: \(message)"
         case .decodingFailed(let message):
             return "DecodingFailed: \(message)"
         case .unknownError(let message):

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
@@ -26,13 +26,17 @@ final class FirestoreService {
         await fetch(from: .orders, as: FSOrders.self)
     }
 
-    func createOrder(_ order: FSOrderDocumentForCreation) async -> Result<Void, FSError> {
-        await create(from: order, to: .orders)
+    func createOrder(_ fsOrder: FSOrder) async -> Result<Void, FSError> {
+        let document = FSOrderDocumentForCreation(from: fsOrder)
+        return await create(from: document, to: .orders, as: fsOrder.id.stringValue)
     }
 }
 
 private extension FirestoreService {
-    func fetch<T: Decodable>(from path: FSPath, as type: T.Type) async -> Result<T, FSError> {
+    func fetch<T: Decodable>(
+        from path: FSPath,
+        as type: T.Type
+    ) async -> Result<T, FSError> {
         let urlString = "\(baseURL)/\(path)"
         guard let url = URL(string: urlString) else {
             return .failure(.invalidURL(urlString: urlString))
@@ -64,8 +68,12 @@ private extension FirestoreService {
         }
     }
 
-    func create<T: Encodable>(from document: T, to path: FSPath) async -> Result<Void, FSError> {
-        let urlString = "\(baseURL)/\(path)"
+    func create<T: Encodable>(
+        from document: T,
+        to path: FSPath,
+        as documentID: String
+    ) async -> Result<Void, FSError> {
+        let urlString = "\(baseURL)/\(path)?documentId=\(documentID)"
         guard let url = URL(string: urlString) else {
             return .failure(.invalidURL(urlString: urlString))
         }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
@@ -25,6 +25,10 @@ final class FirestoreService {
     func fetchOrders() async -> Result<FSOrders, FSError> {
         await fetch(from: .orders, as: FSOrders.self)
     }
+
+    func createOrder(_ order: FSOrderDocumentForCreation) async -> Result<Void, FSError> {
+        await create(from: order, to: .orders)
+    }
 }
 
 private extension FirestoreService {
@@ -55,6 +59,41 @@ private extension FirestoreService {
             } catch {
                 return .failure(.decodingFailed(message: error.localizedDescription))
             }
+        } catch {
+            return .failure(.unknownError(message: error.localizedDescription))
+        }
+    }
+
+    func create<T: Encodable>(from document: T, to path: FSPath) async -> Result<Void, FSError> {
+        let urlString = "\(baseURL)/\(path)"
+        guard let url = URL(string: urlString) else {
+            return .failure(.invalidURL(urlString: urlString))
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            let jsonData = try JSONEncoder().encode(document)
+            request.httpBody = jsonData
+        } catch {
+            return .failure(.encodingFailed(message: error.localizedDescription))
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200...299).contains(httpResponse.statusCode) {
+                return .failure(.httpError(statusCode: httpResponse.statusCode))
+            }
+
+            guard !data.isEmpty else {
+                return .failure(.noData)
+            }
+
+            return .success(())
         } catch {
             return .failure(.unknownError(message: error.localizedDescription))
         }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Domain/Entity/Order.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Domain/Entity/Order.swift
@@ -5,6 +5,12 @@ struct Order {
     let paymentDate: Date
     let orderDetails: OrderDetails
 
+    init(id: String, paymentDate: Date, orderDetails: OrderDetails) {
+        self.id = id
+        self.paymentDate = paymentDate
+        self.orderDetails = orderDetails
+    }
+
     init(from dto: FSOrder) {
         self.id = dto.id.stringValue
         self.paymentDate = Date(from: dto.paymentDate.stringValue) ?? Date(timeIntervalSince1970: 0)
@@ -18,6 +24,11 @@ typealias Orders = [Order]
 struct OrderDetail {
     let menuItemID: String
     let quantity: Int
+
+    init(menuItemID: String, quantity: Int) {
+        self.menuItemID = menuItemID
+        self.quantity = quantity
+    }
 
     init(from dto: FSOrderDetail) {
         self.menuItemID = dto.menuItemID.stringValue


### PR DESCRIPTION
## 🔗 관련 이슈
close #35 

## 📌 PR 요약
Firestore에 Order를 추가하는 로직을 구현했습니다.

## 🔖 작업 내용
- [x] DTO들이 Codable을 채택하도록 변경
- [x] Create를 위한 타입인 FSOrderDocumentForCreation 정의
- [x] 타입 간의 Conversion Initializer(?) 구현
- [x] encodingFailed ErrorType 추가
- [x] createOrder 구현

## 🎆 스크린샷
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/cfb7a527-ce28-40db-921f-cba8b520b8ba" />
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/b16f64eb-d741-49b4-9361-e27fefdf0e70" />
