### PR TITLE
PlaceOrderView 구현

### DIFF
--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/FirestoreService.swift
@@ -27,6 +27,8 @@ final class FirestoreService {
     }
 
     func createOrder(_ fsOrder: FSOrder) async -> Result<Void, FSError> {
+        try? await Task.sleep(nanoseconds: 2_000_000_000) // 결제에 2초 정도 시간이 걸린다고 가정함
+
         let document = FSOrderDocumentForCreation(from: fsOrder)
         return await create(from: document, to: .orders, as: fsOrder.id.stringValue)
     }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/Repository/MenuRepository.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/Repository/MenuRepository.swift
@@ -5,7 +5,7 @@ protocol MenuRepositoryProtocol {
     func fetchMenuItems(for categoryID: String) async -> Result<MenuItems, FSError>
 }
 
-class MenuRepository: MenuRepositoryProtocol {
+final class MenuRepository: MenuRepositoryProtocol {
     private let service: FirestoreService
 
     init(service: FirestoreService = FirestoreService()) {

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Data/Repository/OrderRepository.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Data/Repository/OrderRepository.swift
@@ -4,7 +4,7 @@ protocol OrderRepositoryProtocol {
     func placeOrder(for cart: Cart) async -> Result<Void, FSError>
 }
 
-class OrderRepository: OrderRepositoryProtocol {
+final class OrderRepository: OrderRepositoryProtocol {
     private let service: FirestoreService
 
     init(service: FirestoreService = FirestoreService()) {

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Domain/UseCase/OrderUseCase.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Domain/UseCase/OrderUseCase.swift
@@ -2,10 +2,13 @@ import Foundation
 import RxSwift
 
 protocol OrderUseCaseProtocol {
+    var orderSuccess: PublishSubject<Void> { get }
+    var errerMessage: PublishSubject<String> { get }
+
     func placeOrder(for cart: Cart) async
 }
 
-class OrderUseCase: OrderUseCaseProtocol {
+final class OrderUseCase: OrderUseCaseProtocol {
     private let repository: OrderRepositoryProtocol
     let orderSuccess = PublishSubject<Void>()
     let errerMessage = PublishSubject<String>()

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -193,7 +193,7 @@ private extension MainViewController {
             .observe(on: MainScheduler.instance)
             .bind { [weak self] isEnabled in
                 guard let self else { return }
-                () // TODO: cancelButtonIsEnabled
+                self.placeOrderView.updateCancelButtonIsEnabled(isEnabled)
             }
             .disposed(by: disposeBag)
 
@@ -201,7 +201,7 @@ private extension MainViewController {
             .observe(on: MainScheduler.instance)
             .bind { [weak self] isEnabled in
                 guard let self else { return }
-                () // TODO: orderButtonIsEnabled
+                self.placeOrderView.updateOrderButtonIsEnabled(isEnabled)
             }
             .disposed(by: disposeBag)
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -140,7 +140,7 @@ private extension MainViewController {
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(logoImageView.snp.bottom).offset(16)
             make.directionalHorizontalEdges.equalToSuperview()
-            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20) // 하단 플로팅 버튼 공간 확보
+            make.bottom.equalTo(placeOrderView.snp.top)
         }
 
         placeOrderView.snp.makeConstraints { make in

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -209,6 +209,13 @@ private extension MainViewController {
             }
             .disposed(by: disposeBag)
 
+        output.orderSuccess
+            .bind { [weak self] in
+                guard let self else { return }
+                self.placeOrderView.showOrderSuccessMessage()
+            }
+            .disposed(by: disposeBag)
+
         output.errorMessage
             .bind { message in
                 print(message)

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -161,6 +161,10 @@ private extension MainViewController {
 
         Observable.combineLatest(output.categories, output.menuItems, output.cart)
             .observe(on: MainScheduler.instance)
+            .do { [weak self] _, _, cart in
+                guard let self else { return }
+                self.placeOrderView.updateOrderButtonTitle(with: cart)
+            }
             .bind { [weak self] categories, menuItems, cart in
                 guard let self else { return }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -43,6 +43,8 @@ final class MainViewController: UIViewController {
         return collectionView
     }()
 
+    private let placeOrderView = PlaceOrderView()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configure()
@@ -63,7 +65,7 @@ private extension MainViewController {
     }
     
     func setHierarchy() {
-        view.addSubviews(logoImageView, collectionView)
+        view.addSubviews(logoImageView, collectionView, placeOrderView)
     }
 
     func setDataSource() {
@@ -139,6 +141,11 @@ private extension MainViewController {
             make.top.equalTo(logoImageView.snp.bottom).offset(16)
             make.directionalHorizontalEdges.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20) // 하단 플로팅 버튼 공간 확보
+        }
+
+        placeOrderView.snp.makeConstraints { make in
+            make.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalToSuperview()
         }
     }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -234,7 +234,9 @@ private extension MainViewController {
         placeOrderView.cancelButtonTapped
             .bind { [weak self] in
                 guard let self else { return }
-                self.resetCart.accept(())
+                self.showResetCartAlert {
+                    self.resetCart.accept(())
+                }
             }
             .disposed(by: disposeBag)
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -193,11 +193,11 @@ private extension MainViewController {
             }
             .disposed(by: disposeBag)
 
-        output.cancelButtonIsEnabled
+        output.cancelButtonIsHidden
             .observe(on: MainScheduler.instance)
-            .bind { [weak self] isEnabled in
+            .bind { [weak self] isHidden in
                 guard let self else { return }
-                self.placeOrderView.updateCancelButtonIsEnabled(isEnabled)
+                self.placeOrderView.updateCancelButtonIsHidden(isHidden)
             }
             .disposed(by: disposeBag)
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -230,6 +230,20 @@ private extension MainViewController {
                 }
             }
             .disposed(by: disposeBag)
+
+        placeOrderView.cancelButtonTapped
+            .bind { [weak self] in
+                guard let self else { return }
+                self.resetCart.accept(())
+            }
+            .disposed(by: disposeBag)
+
+        placeOrderView.orderButtonTapped
+            .bind { [weak self] in
+                guard let self else { return }
+                self.placeOrder.accept(())
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewController.swift
@@ -82,8 +82,8 @@ private extension MainViewController {
                     if indexPath.section == 0 && indexPath.item == 0 {
                         collectionView.selectItem(
                             at: IndexPath(item: 0, section: 0),
-                            animated: true,
-                            scrollPosition: .centeredVertically
+                            animated: false,
+                            scrollPosition: .centeredHorizontally
                         )
                     }
                     return cell

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewModel.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewModel.swift
@@ -11,6 +11,7 @@ protocol MainViewModelProtocol: AnyObject {
 
 final class MainViewModel: MainViewModelProtocol {
     private let menuUseCase: MenuUseCaseProtocol = MenuUseCase()
+    private let orderUseCase: OrderUseCaseProtocol = OrderUseCase()
 
     private var cart = BehaviorRelay<Cart>(value: Cart())
     private let disposeBag = DisposeBag()
@@ -77,7 +78,7 @@ final class MainViewModel: MainViewModelProtocol {
             .bind { [weak self] in
                 guard let self else { return }
                 Task {
-                    // TODO: OrderUseCase.placeOrder(with: self.cart.value)
+                    await self.orderUseCase.placeOrder(for: self.cart.value)
                     self.cart.accept(Cart())
                 }
             }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewModel.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewModel.swift
@@ -30,6 +30,7 @@ final class MainViewModel: MainViewModelProtocol {
         let cart: Observable<Cart>
         let cancelButtonIsHidden = BehaviorRelay<Bool>(value: true)
         let orderButtonIsEnabled = BehaviorRelay<Bool>(value: false)
+        let orderSuccess = PublishRelay<Void>()
         let errorMessage = BehaviorRelay<String>(value: "")
     }
     
@@ -93,6 +94,14 @@ final class MainViewModel: MainViewModelProtocol {
             .disposed(by: disposeBag)
 
         menuUseCase.errorMessage
+            .bind(to: output.errorMessage)
+            .disposed(by: disposeBag)
+
+        orderUseCase.orderSuccess
+            .bind(to: output.orderSuccess)
+            .disposed(by: disposeBag)
+
+        orderUseCase.errerMessage
             .bind(to: output.errorMessage)
             .disposed(by: disposeBag)
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewModel.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/MainViewModel.swift
@@ -28,7 +28,7 @@ final class MainViewModel: MainViewModelProtocol {
         let categories = BehaviorRelay<Categories>(value: [])
         let menuItems = BehaviorRelay<MenuItems>(value: [])
         let cart: Observable<Cart>
-        let cancelButtonIsEnabled = BehaviorRelay<Bool>(value: false)
+        let cancelButtonIsHidden = BehaviorRelay<Bool>(value: true)
         let orderButtonIsEnabled = BehaviorRelay<Bool>(value: false)
         let errorMessage = BehaviorRelay<String>(value: "")
     }
@@ -98,7 +98,7 @@ final class MainViewModel: MainViewModelProtocol {
 
         cart
             .bind { cart in
-                output.cancelButtonIsEnabled.accept(cart.totalQuantity > 0)
+                output.cancelButtonIsHidden.accept(cart.totalQuantity == 0)
                 output.orderButtonIsEnabled.accept(cart.totalQuantity > 0)
             }
             .disposed(by: disposeBag)

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Section.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Section.swift
@@ -134,7 +134,7 @@ enum Section: Hashable {
         // 그룹 크기 설정 (수직 스크롤이므로 한 행에 하나의 아이템)
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(140)
+            heightDimension: .estimated(120)
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
@@ -143,8 +143,8 @@ enum Section: Hashable {
 
         // 섹션 설정
         let section = NSCollectionLayoutSection(group: group)
-        section.interGroupSpacing = 10 // 아이템 간 간격
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12) // 좌우 여백 설정
+        section.interGroupSpacing = 16 // 아이템 간 간격
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 16, trailing: 12) // 좌우 여백 설정
 
         // 헤더 설정
         let headerSize = NSCollectionLayoutSize(

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/Cell/CartItemCell.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/Cell/CartItemCell.swift
@@ -121,9 +121,9 @@ private extension CartItemCell {
 
     func setConstraints() {
         containerView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(4)
+            make.top.equalToSuperview()
             make.directionalHorizontalEdges.equalToSuperview()
-            make.bottom.equalToSuperview().inset(12)
+            make.bottom.equalToSuperview()
         }
 
         itemImageView.snp.makeConstraints { make in

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -147,7 +147,7 @@ private extension PlaceOrderView {
         buttonsStackView.snp.makeConstraints { make in
             make.top.equalTo(franchiseLabel.snp.bottom).offset(14)
             make.directionalHorizontalEdges.equalToSuperview().inset(24)
-            make.bottom.equalTo(safeAreaLayoutGuide)
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(14)
         }
 
         cancelButton.snp.makeConstraints { make in

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -57,9 +57,9 @@ final class PlaceOrderView: UIView {
         fatalError("init(coder:) has not been implemented.")
     }
 
-    func updateCancelButtonIsEnabled(_ isEnabled: Bool) {
+    func updateCancelButtonIsHidden(_ isHidden: Bool) {
         UIView.transition(with: cancelButton, duration: 0.2, options: .transitionCrossDissolve) {
-            self.cancelButton.isHidden = !isEnabled
+            self.cancelButton.isHidden = isHidden
         }
     }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -26,7 +26,6 @@ final class PlaceOrderView: UIView {
     private lazy var orderButton: UIButton = {
         let button = UIButton(type: .system)
         button.backgroundColor = .bcPrimary
-        button.setTitle("(2) 25,000원 결제하기", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.titleLabel?.font = .nanumSquareRound(ofSize: 15, weight: .heavy)
         button.layer.cornerRadius = 20
@@ -51,6 +50,13 @@ final class PlaceOrderView: UIView {
 
     func updateOrderButtonIsEnabled(_ isEnabled: Bool) {
         orderButton.isEnabled = isEnabled
+    }
+
+    func updateOrderButtonTitle(with cart: Cart) {
+        let title = cart.totalQuantity == 0
+            ? "항목을 추가해주세요!"
+            : "(\(cart.totalQuantity)) \(cart.totalPrice)원 결제하기"
+        orderButton.setTitle(title, for: .normal)
     }
 }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -52,10 +52,12 @@ final class PlaceOrderView: UIView {
 
     func updateCancelButtonIsEnabled(_ isEnabled: Bool) {
         cancelButton.isEnabled = isEnabled
+        cancelButton.layer.opacity = isEnabled ? 1.0 : 0.5
     }
 
     func updateOrderButtonIsEnabled(_ isEnabled: Bool) {
         orderButton.isEnabled = isEnabled
+        orderButton.layer.opacity = isEnabled ? 1.0 : 0.5
     }
 
     func updateOrderButtonTitle(with cart: Cart) {
@@ -102,10 +104,10 @@ private extension PlaceOrderView {
         }
 
         orderButton.snp.makeConstraints { make in
+            make.top.equalTo(franchiseLabel.snp.bottom).offset(14)
             make.leading.equalTo(cancelButton.snp.trailing).offset(16)
             make.trailing.equalToSuperview().inset(24)
-            make.height.equalTo(cancelButton.snp.height)
-            make.centerY.equalTo(cancelButton.snp.centerY)
+            make.height.equalTo(42)
         }
     }
 

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -17,6 +17,13 @@ final class PlaceOrderView: UIView {
         return label
     }()
 
+    private lazy var buttonsStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 16
+        return stackView
+    }()
+
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
         button.backgroundColor = .bcBackground4
@@ -51,8 +58,9 @@ final class PlaceOrderView: UIView {
     }
 
     func updateCancelButtonIsEnabled(_ isEnabled: Bool) {
-        cancelButton.isEnabled = isEnabled
-        cancelButton.layer.opacity = isEnabled ? 1.0 : 0.5
+        UIView.transition(with: cancelButton, duration: 0.2, options: .transitionCrossDissolve) {
+            self.cancelButton.isHidden = !isEnabled
+        }
     }
 
     func updateOrderButtonIsEnabled(_ isEnabled: Bool) {
@@ -86,7 +94,8 @@ private extension PlaceOrderView {
     }
 
     func setHierarchy() {
-        addSubviews(franchiseLabel, cancelButton, orderButton)
+        buttonsStackView.addArrangedSubviews(cancelButton, orderButton)
+        addSubviews(franchiseLabel, buttonsStackView)
     }
 
     func setConstraints() {
@@ -95,18 +104,18 @@ private extension PlaceOrderView {
             make.leading.equalToSuperview().inset(24)
         }
 
-        cancelButton.snp.makeConstraints { make in
+        buttonsStackView.snp.makeConstraints { make in
             make.top.equalTo(franchiseLabel.snp.bottom).offset(14)
-            make.leading.equalToSuperview().inset(24)
+            make.directionalHorizontalEdges.equalToSuperview().inset(24)
             make.bottom.equalTo(safeAreaLayoutGuide)
+        }
+
+        cancelButton.snp.makeConstraints { make in
             make.width.equalTo(90)
             make.height.equalTo(42)
         }
 
         orderButton.snp.makeConstraints { make in
-            make.top.equalTo(franchiseLabel.snp.bottom).offset(14)
-            make.leading.equalTo(cancelButton.snp.trailing).offset(16)
-            make.trailing.equalToSuperview().inset(24)
             make.height.equalTo(42)
         }
     }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -1,7 +1,13 @@
 import UIKit
 import SnapKit
+import RxSwift
+import RxCocoa
 
 final class PlaceOrderView: UIView {
+    let cancelButtonTapped = PublishRelay<Void>()
+    let orderButtonTapped = PublishRelay<Void>()
+    private let disposeBag = DisposeBag()
+
     private lazy var franchiseLabel: UILabel = {
         let label = UILabel()
         label.text = "내버캠 iOS 마스터 3호점"
@@ -65,6 +71,7 @@ private extension PlaceOrderView {
         setLayout()
         setHierarchy()
         setConstraints()
+        setBinding()
     }
 
     func setLayout() {
@@ -100,5 +107,15 @@ private extension PlaceOrderView {
             make.height.equalTo(cancelButton.snp.height)
             make.centerY.equalTo(cancelButton.snp.centerY)
         }
+    }
+
+    func setBinding() {
+        cancelButton.rx.tap
+            .bind(to: cancelButtonTapped)
+            .disposed(by: disposeBag)
+
+        orderButton.rx.tap
+            .bind(to: orderButtonTapped)
+            .disposed(by: disposeBag)
     }
 }

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -44,6 +44,14 @@ final class PlaceOrderView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented.")
     }
+
+    func updateCancelButtonIsEnabled(_ isEnabled: Bool) {
+        cancelButton.isEnabled = isEnabled
+    }
+
+    func updateOrderButtonIsEnabled(_ isEnabled: Bool) {
+        orderButton.isEnabled = isEnabled
+    }
 }
 
 private extension PlaceOrderView {

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Presentation/Main/Subview/PlaceOrderView.swift
@@ -1,0 +1,90 @@
+import UIKit
+import SnapKit
+
+final class PlaceOrderView: UIView {
+    private lazy var franchiseLabel: UILabel = {
+        let label = UILabel()
+        label.text = "내버캠 iOS 마스터 3호점"
+        label.textColor = .bcMocha
+        label.font = .nanumSquareRound(ofSize: 13, weight: .heavy)
+
+        return label
+    }()
+
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.backgroundColor = .bcBackground4
+        button.setTitle("취소", for: .normal)
+        button.setTitleColor(.bcBlack, for: .normal)
+        button.titleLabel?.font = .nanumSquareRound(ofSize: 15, weight: .heavy)
+        button.layer.cornerRadius = 20
+        button.clipsToBounds = true
+
+        return button
+    }()
+
+    private lazy var orderButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.backgroundColor = .bcPrimary
+        button.setTitle("(2) 25,000원 결제하기", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .nanumSquareRound(ofSize: 15, weight: .heavy)
+        button.layer.cornerRadius = 20
+        button.clipsToBounds = true
+
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    @available(*, unavailable, message: "storyboard is not supported")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+}
+
+private extension PlaceOrderView {
+    func configure() {
+        setLayout()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setLayout() {
+        backgroundColor = .bcBackground3
+
+        layer.shadowColor = UIColor(named: "BCBlack")?.cgColor
+        layer.shadowOpacity = 0.2
+        layer.shadowRadius = 5
+        layer.shadowOffset = CGSize(width: 0, height: -2)
+    }
+
+    func setHierarchy() {
+        addSubviews(franchiseLabel, cancelButton, orderButton)
+    }
+
+    func setConstraints() {
+        franchiseLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(12)
+            make.leading.equalToSuperview().inset(24)
+        }
+
+        cancelButton.snp.makeConstraints { make in
+            make.top.equalTo(franchiseLabel.snp.bottom).offset(14)
+            make.leading.equalToSuperview().inset(24)
+            make.bottom.equalTo(safeAreaLayoutGuide)
+            make.width.equalTo(90)
+            make.height.equalTo(42)
+        }
+
+        orderButton.snp.makeConstraints { make in
+            make.leading.equalTo(cancelButton.snp.trailing).offset(16)
+            make.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(cancelButton.snp.height)
+            make.centerY.equalTo(cancelButton.snp.centerY)
+        }
+    }
+}

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Utility/UIStackView+Extensions.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Utility/UIStackView+Extensions.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+extension UIStackView {
+    func addArrangedSubviews(_ views: UIView...) {
+        views.forEach {
+            self.addArrangedSubview($0)
+        }
+    }
+}

--- a/NaeilBurgerCamp/NaeilBurgerCamp/Utility/UIViewController+Extensions.swift
+++ b/NaeilBurgerCamp/NaeilBurgerCamp/Utility/UIViewController+Extensions.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+extension UIViewController {
+    func showResetCartAlert(completionHandler: @escaping () -> Void) {
+        let alert = UIAlertController(
+            title: "주문 취소",
+            message: "정말로 주문을 취소하시겠어요?",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "아니요", style: .cancel))
+        alert.addAction(UIAlertAction(title: "네", style: .destructive, handler: { _ in
+            completionHandler()
+        }))
+
+        self.present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
close #33 

## 📌 PR 요약
PlaceOrderView 구현입니다.

## 🔖 작업 내용
- [x] PlaceOrderView UI 및 로직 구현
- [x] Cart 상태 변화에 따른 OrderButton Title 갱신
- [x] Cart가 비어있으면 취소 버튼 숨기는 기능 구현
- [x] CancelButton Tap할 시, Alert로 재확인하는 기능 구현
- [x] OrderButton Tap할 시, 주문기능 구현(Firestore에 추가되는 것까지 확인)

## 🎆 스크린샷
![2025-04-10 02 48 52](https://github.com/user-attachments/assets/9b96b04a-73c5-4b10-94a4-1c1d71194ead)

## 💡 추가 참고 사항
* 주문 성공 시, feedback을 띄우기
* totalAmount를 원형 label에 표시하기

이 두가지 기능은 다음 PR에서 구현하겠습니다~